### PR TITLE
deps: Upgrade graceful-fs dependency to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "tmp": "0.0.24"
   },
   "dependencies": {
-    "graceful-fs": "^3.0.2",
+    "graceful-fs": "^4.1.2",
     "path-is-inside": "^1.0.1",
     "rimraf": "^2.2.8"
   }


### PR DESCRIPTION
graceful-fs used to monkey-patch node's core fs module.
This has been fixed in the version 4.

Related: https://github.com/nodejs/node/pull/2714